### PR TITLE
Made some translations more fitting

### DIFF
--- a/lang.tr.json
+++ b/lang.tr.json
@@ -21,19 +21,19 @@
 
             "isitdownupmsg": "Yukarı",
 
-            "isitdowntitleseperator": "is",
+            "isitdowntitleseperator": ":",
 
             "isitdownnotexistmsg": "Alan adı geçersiz.",
 
             "infotitleinfostring": "Bilgi:",
 
-            "infoguildcount": "Lonca Sayısı:",
+            "infoguildcount": "Sunucu Sayısı:",
 
             "infousercount": "Kullanıcı Sayısı:",
 
             "infochannelcount": "Kanal Sayısı:",
 
-            "infoshardid": "Kırık ID:",
+            "infoshardid": "Parça ID:",
 
             "notinoperation": "Bu komut şu anda kullanılamıyor!",
             


### PR DESCRIPTION
Changed "is" to ":" to better fit the context transtlation.

Changed "Lonca" to "Sunucu" to make it more commonly understood. 

"Kırık" to "Parça" to attempt to make a discord term more understandable.

 These changes should be better readable by Turks.