### PR TITLE
Premium strings in Turkish

### DIFF
--- a/lang.tr.json
+++ b/lang.tr.json
@@ -38,6 +38,22 @@
             "notinoperation": "Bu komut şu anda kullanılamıyor!",
             
             "languageset": "Dil ayarlandı!"
+			
+            "premiumtokenstitle": "Tokenleriniz: {{amt}}",
+
+            "cancel": "İptal",
+
+            "confirm": "Onayla",
+
+            "redeempremconfirm": "Bu sunucuda premium kullanmak istediğinizden emin misiniz?",
+
+            "premnotenoughtokens": "Bunun için yeterli tokeniniz yok, {{tokens}} tokene ihtiyacınız var!",
+
+            "premcancel": "Tamam, işlem iptal edilmiştir!",
+
+            "premsuccess": "Başarılı! {{plan}} planınız {{days}} gün için uygulanmıştır!",
+
+            "premalreadygot": "Bu sunucunun zaten premiumu var!"
         }
     },
     "refs": {}


### PR DESCRIPTION
Translated and added premium strings.

I used the second person singular with respect, should be applicable.

I translated the tense directly, "has been" became "-miş-tir" compound (?) time. Forgor what official translations use, but this absolutely works.

not sure about "premsuccess", it gets across but it could be better a different way when it's Turkish.

Thanks.